### PR TITLE
Update cluster profile 

### DIFF
--- a/workflow/profiles/default/config.yaml
+++ b/workflow/profiles/default/config.yaml
@@ -1,4 +1,4 @@
-executor: slurm
+executor: local
 jobs: 999
 local-cores: 1
 cores: 10


### PR DESCRIPTION
Adds a default cluster profile. User needs to add account name and change executor to `slurm`