### PR TITLE
Ch4 tracking removed from gsa

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -25,16 +25,11 @@ if config["scenario"]["include_generated"]: # gets model specific params
 else:
     GSA_PARAMETERS = pd.read_csv(config["gsa"]["parameters"])
 
-# TODO: This messes up the counting of samples as the parameter.csv still has ch4
-# also, if we treat ch4 as a set value, then the ua parameter csv will miss that
-"""
 # if not tracking ch4, treat it as a static value 
-if config["scenario"]["ch4"]: 
-    GSA_GROUPS = GSA_PARAMETERS.group.unique().tolist()
-else:
+if not config["scenario"]["ch4"]: 
     to_remove = ["ng_leakage_upstream", "ng_leakage_downstream", "ng_gwp"]
-    GSA_GROUPS = [x for x in GSA_PARAMETERS.group.unique() if x not in to_remove]
-"""
+    GSA_PARAMETERS = GSA_PARAMETERS[~GSA_PARAMETERS.name.isin(to_remove)].copy()
+
 GSA_GROUPS = GSA_PARAMETERS.group.unique().tolist()
 
 GSA_RESULTS = pd.read_csv(config["gsa"]["results"])

--- a/workflow/rules/prepare.smk
+++ b/workflow/rules/prepare.smk
@@ -128,6 +128,8 @@ rule sanitize_parameters:
         parameters=get_input_parameters_file
     output:
         parameters="results/{scenario}/gsa/parameters.csv"
+    params:
+        track_ch4=config["scenario"]["ch4"],
     log: 
         "logs/sanitize_parameters/{scenario}.log"
     benchmark:

--- a/workflow/scripts/sanitize_params.py
+++ b/workflow/scripts/sanitize_params.py
@@ -499,19 +499,30 @@ def is_attr_t_pct(params: pd.DataFrame) -> bool:
     else:
         return True
 
+def remove_ch4(params: pd.DataFrame) -> pd.DataFrame:
+    """Removes ch4 from the parameters file."""
+    df = params.copy()
+    to_remove = ["ng_leakage_upstream", "ng_leakage_downstream", "ng_gwp"]
+    df = df[~df.name.isin(to_remove)].copy()
+    return df
 
 if __name__ == "__main__":
 
     if "snakemake" in globals():
         in_params = snakemake.input.parameters
         out_params = snakemake.output.parameters
+        track_ch4 = snakemake.params.track_ch4
         configure_logging(snakemake)
     else:
         in_params = "config/parameters.csv"
         out_params = "results/Test/parameters.csv"
+        track_ch4 = False
     
     df = pd.read_csv(in_params, dtype={"min_value": float, "max_value": float})
     
+    if track_ch4:
+        df = remove_ch4(df)
+        
     # top level sanitize 
     df = sanitize_component_name(df)
     df = strip_whitespace(df)


### PR DESCRIPTION
Removes the tracking of CH4 from the GSA sample. This is needed as infeasabilities are often encountered in ch4 leaks are included. 